### PR TITLE
Add RISC-V block list and skip test for RISC-V

### DIFF
--- a/test/inductor/test_cpu_select_algorithm.py
+++ b/test/inductor/test_cpu_select_algorithm.py
@@ -1559,6 +1559,7 @@ class TestSelectAlgorithm(BaseTestSelectAlgorithm):
         vec_amx = VecAMX()
         self._check_amx_counter(vec_amx)
 
+    @unittest.skipIf(not torch._C._has_mkldnn, "MKLDNN is not enabled")
     @inductor_config.patch({"freezing": True})
     @patches
     @torch.no_grad
@@ -1672,6 +1673,7 @@ class TestSelectAlgorithm(BaseTestSelectAlgorithm):
             vec_amx = VecAMX()
             self._check_amx_counter(vec_amx)
 
+    @unittest.skipIf(not torch._C._has_mkldnn, "MKLDNN is not enabled")
     @inductor_config.patch({"freezing": True, "cpp.enable_concat_linear": True})
     @patches
     @torch.no_grad

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -304,7 +304,6 @@ RISCV64_BLOCKLIST = [
     # Failed to import torch.distributed.run: cannot import name 'Store' from 'torch.distributed'
     "test_testing"
     # TODO:L1 cache size = 0, need to fix
-    "inductor/test_cpu_select_algorithm"
     "inductor/test_aot_inductor_arrayref"
     "inductor/test_cpu_repro"
     # TODO:scalar value not equal, need to fix

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -108,6 +108,7 @@ DISTRIBUTED_TEST_PREFIX = "distributed"
 INDUCTOR_TEST_PREFIX = "inductor"
 IS_SLOW = "slow" in TEST_CONFIG or "slow" in BUILD_ENVIRONMENT
 IS_S390X = platform.machine() == "s390x"
+IS_RISCV64 = platform.machine() == "riscv64"
 
 
 # Note [ROCm parallel CI testing]
@@ -280,6 +281,45 @@ XPU_BLOCKLIST = [
 XPU_TEST = [
     "test_xpu",
 ]
+
+RISCV64_BLOCKLIST = [
+    # disable distributed related test
+    "inductor/test_distributed_patterns"
+    "fx/test_dce_pass"
+    "export/test_cpp_serdes"
+    "export/test_export"
+    "export/test_export_strict"
+    "export/test_export_training_ir_to_run_decomp"
+    "export/test_retraceability"
+    "export/test_serdes"
+    "export/test_strict_export_v2"
+    "test_public_bindings"
+    # quantized engine NoQEngine is not supported
+    "test_torch"
+    "ao/sparsity/test_composability"
+    # QNNPACK is not supported
+    "export/test_converter"
+    # record_contex_cpp is not support on non-linux non-x86_64 platforms
+    "torch_np/numpy_tests/core/test_numeric"
+    # Failed to import torch.distributed.run: cannot import name 'Store' from 'torch.distributed'
+    "test_testing"
+    # TODO:L1 cache size = 0, need to fix
+    "inductor/test_cpu_select_algorithm"
+    "inductor/test_aot_inductor_arrayref"
+    "inductor/test_cpu_repro"
+    # TODO:scalar value not equal, need to fix
+    "profiler/test_profiler"
+    # TODO precision
+    "test_binary_ufuncs"
+    "test_decomp"
+    # TODO no CUDA related module
+    "quantization/core/test_workflow_module"  # TestFakeQuantize.test_fq_module_per_channel
+    "quantization/core/test_workflow_ops"
+    "quantization/core/test_quantized_op"
+    # z3-solver build fail
+    "test_proxy_tensor"
+]
+
 
 # The tests inside these files should never be run in parallel with each other
 RUN_PARALLEL_BLOCKLIST = [
@@ -1821,6 +1861,13 @@ def get_selected_tests(options) -> list[str]:
             DISTRIBUTED_TESTS,
             selected_tests,
             "Skip distributed tests on s390x",
+        )
+    elif IS_RISCV64:
+        selected_tests = exclude_tests(RISCV64_BLOCKLIST, selected_tests, "on riscv64")
+        selected_tests = exclude_tests(
+            DISTRIBUTED_TESTS,
+            selected_tests,
+            "Skip distributed tests on riscv64",
         )
 
     # skip all distributed tests if distributed package is not available.

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -8954,6 +8954,7 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
         with self.assertRaisesRegex(RuntimeError, "must be batches of square matrices"):
             torch.ops.aten.matrix_exp_backward(non_square, grad_non_square)
 
+    @slowTest
     @skipCUDAIfNoMagma
     @skipCPUIfNoLapack
     @dtypes(torch.float, torch.double, torch.complex64, torch.complex128)


### PR DESCRIPTION
1. Remove test/inductor/test_cpu_select_algorithm.py from block list.
2. Add hint for test/inductor/test_cpu_select_algorithm.py to skip test, oneDNN and mlkdnn is unavailable for RISC-V now.