### PR TITLE
Fix bytes_to_scalar for float/complex on RISC-V

### DIFF
--- a/.github/workflows/ci-riscv64.yml
+++ b/.github/workflows/ci-riscv64.yml
@@ -60,7 +60,7 @@ jobs:
             git fetch --quiet origin pull/${{ github.event.pull_request.number }}/head:pr-head
             git fetch --quiet origin main
             BASE=$(git merge-base pr-head origin/main)
-            HEAD=pr-head
+            HEAD=$(git rev-parse pr-head)
           else
             echo "Push to riscv"
             # 统一用 riscv 作为 baseline

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -294,8 +294,6 @@ RISCV64_BLOCKLIST = [
     "export/test_serdes",
     "export/test_strict_export_v2",
     "test_public_bindings",
-    # quantized engine NoQEngine is not supported
-    "test_torch",
     "ao/sparsity/test_composability",
     # QNNPACK is not supported
     "export/test_converter",
@@ -318,6 +316,15 @@ RISCV64_BLOCKLIST = [
     "quantization/core/test_quantized_op",
     # z3-solver build fail
     "test_proxy_tensor",
+    # too slow on riscv64
+    # 53013.55 s
+    "functorch/test_aotdispatch",
+    # 25069 s
+    "functorch/test_ops",
+    # 17528 s
+    "test_transformers",
+    # 10897 s
+    "functorch/test_vmap",
 ]
 
 

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -5457,27 +5457,22 @@ def bytes_to_scalar(byte_list: list[int], dtype: torch.dtype, device: torch.devi
             if not (0 <= byte <= 255):
                 raise AssertionError(f"byte value out of range: expected 0 <= byte <= 255, got {byte}")
 
-    if dtype.is_complex:
-        if len(byte_list) != (num_bytes * 2):
-            raise AssertionError(
-                f"expected len(byte_list) == {num_bytes * 2} for complex dtype, got {len(byte_list)}"
-            )
-        check_bytes(byte_list)
-        real = ctype.from_buffer((ctypes.c_byte * num_bytes)(
-            *byte_list[:num_bytes])).value
-        imag = ctype.from_buffer((ctypes.c_byte * num_bytes)(
-            *byte_list[num_bytes:])).value
-        res = real + 1j * imag
-    else:
-        if len(byte_list) != num_bytes:
-            raise AssertionError(
-                f"expected len(byte_list) == {num_bytes}, got {len(byte_list)}"
-            )
-        check_bytes(byte_list)
-        res = ctype.from_buffer((ctypes.c_byte * num_bytes)(
-            *byte_list)).value
+    expected_len = num_bytes * 2 if dtype.is_complex else num_bytes
+    if len(byte_list) != expected_len:
+        raise AssertionError(
+            f"expected len(byte_list) == {expected_len}"
+            f"{' for complex dtype' if dtype.is_complex else ''}, got {len(byte_list)}"
+        )
+    check_bytes(byte_list)
 
-    return torch.tensor(res, device=device, dtype=dtype)
+    # Write bytes directly into storage to preserve exact bit patterns
+    # (e.g. NaN payloads, which are not preserved when round-tripping through
+    # Python float/complex, especially on architectures like RISC-V that
+    # canonicalize NaNs).
+    res = torch.empty((), dtype=dtype, device=device)
+    src = torch.tensor(byte_list, dtype=torch.uint8, device=device)
+    res.untyped_storage().copy_(src.untyped_storage())
+    return res
 
 
 def copy_func(f):


### PR DESCRIPTION
bytes_to_scalar previously round-tripped raw bytes through Python float/complex values (via ctypes) before constructing the tensor. This loses NaN bit patterns on architectures (such as RISC-V) that canonicalize NaNs in floating-point loads/conversions, causing test_bytes_to_scalar_cpu_{float32,float64,complex64,complex128} to fail with mismatched storage bytes.

Construct the scalar tensor by writing the raw bytes directly into its untyped storage so all input bit patterns (including NaN payloads) are preserved exactly.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>