### PR TITLE
Fix test_float_to_int_conversion_nonfinite for RISC-V

### DIFF
--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -32,6 +32,7 @@ from torch.testing._internal.common_utils import (
     IS_SANDCASTLE,
     IS_S390X,
     IS_ARM64,
+    IS_RISCV64,
     parametrize,
     TEST_WITH_TORCHDYNAMO,
     xfailIfTorchDynamo,
@@ -1109,6 +1110,13 @@ class TestTensorCreation(TestCase):
 
         if dtype == torch.bool:
             refs = (True, True, True)
+        elif IS_RISCV64:
+            if dtype in (torch.int32, torch.int64):
+                refs = (torch.iinfo(dtype).min, torch.iinfo(dtype).max, torch.iinfo(dtype).max)
+            elif dtype == torch.uint8:
+                refs = (0, torch.iinfo(dtype).max, torch.iinfo(dtype).max)
+            elif dtype in (torch.int8, torch.int16):
+                refs = (0, -1, -1)
         elif IS_ARM64:
             refs = (torch.iinfo(dtype).min, torch.iinfo(dtype).max, 0)
             if dtype in (torch.int8, torch.int16):

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1415,6 +1415,7 @@ IS_MACOS = sys.platform == "darwin"
 IS_PPC = platform.machine() == "ppc64le"
 IS_X86 = platform.machine() in ('x86_64', 'i386')
 IS_ARM64 = platform.machine() in ('arm64', 'aarch64')
+IS_RISCV64 = platform.machine() == 'riscv64'
 IS_S390X = platform.machine() == "s390x"
 IS_AVX512_VNNI_SUPPORTED = cpu_supports_feature("vnni")
 IS_CPU_EXT_SVE_SUPPORTED = cpu_supports_feature("sve")


### PR DESCRIPTION
RISC-V converts non-finite floats to integers by saturating: -inf -> min, inf/nan -> max for wider int types.
Add IS_RISCV64 flag and RISC-V-specific reference values.